### PR TITLE
Removes unicode_literals from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from distutils.core import setup
 
 __version__ = '0.0.3'


### PR DESCRIPTION
Importing unicode_literals transforms any free-form
strings to unicode on python 2.7, which causes
python setup.py egg_info to fail, as it expects package_data
to contain strings.